### PR TITLE
Admin toggle by adding staff status as well.

### DIFF
--- a/ds4admin/views.py
+++ b/ds4admin/views.py
@@ -129,6 +129,7 @@ def toggle_group(request, group_type, user_id):
 
     if group_type == 'admin':
         u.is_superuser ^= True
+        u.is_staff ^= True
         u.save()
 
     elif group_type == 'thesau':


### PR DESCRIPTION
Fixes #56 
Staff status moest ook aangezet worden in het geval dat een huisgenoot admin gemaakt werd. Dat gebeurt nu nadat iemand is_superuser status krijgt. (Beide zijn nodig om admin te worden, is_superuser geldt voor admin pagina van ds4.nl, staff status voor de Django admin page.)